### PR TITLE
add connector for LogRoler.RollingFileWriterTee

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The LogCompose.jl package is licensed under the MIT "Expat" License:
 
-> Copyright (c) 2019-2020: Tanmay Mohapatra, Julia Computing
+> Copyright (c) 2020-2021: Tanmay Mohapatra, Julia Computing
 >
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["configure", "compose", "logging", "logger"]
 authors = ["tan <tanmaykm@gmail.com>"]
 license = "MIT"
 desc = "Compose loggers and logger ensembles declaratively using configuration files"
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -18,7 +18,7 @@ LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 julia = "1"
 SyslogLogging = "0.1"
 LoggingExtras = "0.4"
-LogRoller = "0.2"
+LogRoller = "0.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ LogCompose supports the following types of loggers at the moment:
 - Logging.SimpleLogger
 - LoggingExtras.TeeLogger
 - LogRoller.RollingLogger
+- LogRoler.RollingFileWriterTee
 - SyslogLogging.SyslogLogger
 
 ### Plugging in other Loggers

--- a/src/compose.jl
+++ b/src/compose.jl
@@ -54,3 +54,4 @@ end
 logcompose(::Type{T}, config::Dict{String,Any}, logger_config::Dict{String,Any}) where {T} = @error("logcompose not implemented for type $T")
 
 log_min_level(logger_config::Dict{String,Any}, default::String="Info") = getproperty(Logging, Symbol(get(logger_config, "min_level", default)))
+log_assumed_level(logger_config::Dict{String,Any}, default::String="Info") = getproperty(Logging, Symbol(get(logger_config, "assumed_level", default)))

--- a/test/testapp.toml
+++ b/test/testapp.toml
@@ -39,3 +39,11 @@ log_name = "testapp"
 [loggers.testapp]
 type = "LoggingExtras.TeeLogger"
 destinations = ["file.testapp", "syslog.testapp"]
+
+[loggers.testapptee]
+type = "LogRoller.RollingFileWriterTee"
+destination = "file.testapp"
+filename = "/tmp/testapptee.log"
+# sizelimit = 10240000
+# nfiles = 5
+# assumed_level = "Debug"                 # Debug, Info (default) or Error


### PR DESCRIPTION
Add connector for LogRoler.RollingFileWriterTee that can tee a plain log file
(like the ones we get from non-Julia applications) on to a Julia logger.

Ref: https://github.com/tanmaykm/LogRoller.jl/pull/7