### PR TITLE
add connector for LogRoler.RollingFileWriter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["configure", "compose", "logging", "logger"]
 authors = ["tan <tanmaykm@gmail.com>"]
 license = "MIT"
 desc = "Compose loggers and logger ensembles declaratively using configuration files"
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ LogCompose supports the following types of loggers at the moment:
 - LoggingExtras.TeeLogger
 - LogRoller.RollingLogger
 - LogRoler.RollingFileWriterTee
+- LogRoller.RollingFileWriter
 - SyslogLogging.SyslogLogger
 
 ### Plugging in other Loggers

--- a/src/connectors.jl
+++ b/src/connectors.jl
@@ -73,6 +73,16 @@ function logcompose(::typeof(LogRoller.RollingFileWriterTee), config::Dict{Strin
     LogRoller.RollingFileWriterTee(filename, sizelimit, nfiles, destination, level)
 end
 
+function logcompose(::typeof(LogRoller.RollingFileWriter), config::Dict{String,Any}, logger_config::Dict{String,Any})
+    filename = String(strip(logger_config["filename"]))
+    @assert !isempty(filename)
+
+    level = log_assumed_level(logger_config, "Info")
+    sizelimit = get(logger_config, "sizelimit", 10240000)
+    nfiles = get(logger_config, "nfiles", 5)
+    LogRoller.RollingFileWriter(filename, sizelimit, nfiles)
+end
+
 function logcompose(::Type{LoggingExtras.TeeLogger}, config::Dict{String,Any}, logger_config::Dict{String,Any})
     destinations = [LogCompose.logger(config, dest) for dest in logger_config["destinations"]]
     LoggingExtras.TeeLogger(destinations...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,8 +5,10 @@ function test()
     default_logfile = "/tmp/default.log"
     rotated_logfile = "/tmp/testapp.log"
     rotated_tee_logfile = "/tmp/testapptee.log"
+    rotated_plain_logfile = "/tmp/testplain.log"
     rm(rotated_logfile; force=true)
     rm(rotated_tee_logfile; force=true)
+    rm(rotated_plain_logfile; force=true)
     rm(default_logfile; force=true)
 
     let logger = LogCompose.logger(config, "default"; section="loggers")
@@ -42,6 +44,12 @@ function test()
         run(cmd)
     end
 
+    let logger = LogCompose.logger(config, "plainfile"; section="loggers")
+        julia = joinpath(Sys.BINDIR, "julia")
+        cmd = pipeline(`$julia -e 'println("testplainfilewriter"); flush(stdout)'`; stdout=logger, stderr=logger)
+        run(cmd)
+    end
+
     log_file_contents = readlines(default_logfile)
     @test findfirst("testdefault", log_file_contents[1]) !== nothing
 
@@ -52,6 +60,9 @@ function test()
 
     log_file_contents = readlines(rotated_tee_logfile)
     @test "testteefilewriter" == log_file_contents[1]
+
+    log_file_contents = readlines(rotated_plain_logfile)
+    @test "testplainfilewriter" == log_file_contents[1]
 end
 
 test()

--- a/test/testapp.toml
+++ b/test/testapp.toml
@@ -47,3 +47,10 @@ filename = "/tmp/testapptee.log"
 # sizelimit = 10240000
 # nfiles = 5
 # assumed_level = "Debug"                 # Debug, Info (default) or Error
+
+[loggers.plainfile]
+type = "LogRoller.RollingFileWriter"
+filename = "/tmp/testplain.log"
+# sizelimit = 10240000
+# nfiles = 5
+# assumed_level = "Debug"                 # Debug, Info (default) or Error


### PR DESCRIPTION
Add connector for LogRoler.RollingFileWriter that can rotate plain log file
(like the ones we get from non-Julia applications).