### PR TITLE
separate out loggers other than stdlib Logging

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,46 @@
+environment:
+  matrix:
+  - julia_version: 1.0
+  - julia_version: 1.1
+  - julia_version: 1.2
+  - julia_version: 1.3
+  - julia_version: 1.4
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# Uncomment the following lines to allow failures on nightly julia
+# (tests will run but not make your overall status red)
+matrix:
+  allow_failures:
+  - julia_version: nightly
+
+#branches:
+#  only:
+#    - master
+#    - /release-.*/
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
+
+build_script:
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
+
+test_script:
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/Project.toml
+++ b/Project.toml
@@ -1,24 +1,17 @@
 name = "LogCompose"
 uuid = "8416b438-731e-11ea-2421-05f642269042"
 keywords = ["configure", "compose", "logging", "logger"]
-authors = ["tan <tanmaykm@gmail.com>"]
+authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
 license = "MIT"
 desc = "Compose loggers and logger ensembles declaratively using configuration files"
-version = "0.1.2"
+version = "0.2.0"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
-Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
-SyslogLogging = "0c4b0c42-68ec-11ea-3bc9-e7fb6e00ea0f"
-LogRoller = "c41e01d8-14e5-11ea-185b-e7eabed7be4b"
-LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 
 [compat]
 julia = "1"
-SyslogLogging = "0.1"
-LoggingExtras = "0.4"
-LogRoller = "0.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # LogCompose
 
 [![Build Status](https://travis-ci.org/tanmaykm/LogCompose.jl.png)](https://travis-ci.org/tanmaykm/LogCompose.jl) 
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/tanmaykm/LogCompose.jl?branch=master&svg=true)](https://ci.appveyor.com/project/tanmaykm/logroller-jl/branch/master)
 [![Coverage Status](https://coveralls.io/repos/github/tanmaykm/LogCompose.jl/badge.svg?branch=master)](https://coveralls.io/github/tanmaykm/LogCompose.jl?branch=master)
 
 Provides a way to specify hierarchical logging configuration in a file.

--- a/example.toml
+++ b/example.toml
@@ -1,0 +1,56 @@
+[loggers.default]
+type = "Logging.SimpleLogger"
+# min_level = "Debug"                   # Debug, Info (default) or Error
+stream = "/tmp/default.log"             # stdout (default), stderr or a filepath
+
+[loggers.file]
+type = "LogRoller.RollingLogger"
+# sizelimit = 10240000
+# nfiles = 5
+# min_level = "Debug"                   # Debug, Info (default) or Error
+# timestamp_identifier = "time"
+
+[loggers.syslog]
+type = "SyslogLogging.SyslogLogger"
+# min_level = "Info"                      # default is Info
+# facility = "user"                       # one of the facility types listed in Syslogs.jl (default is user)
+# server_type = "tcp"                     # tcp or udp or local (default)
+# server_host = 
+# server_port =
+# lock = false                            # whether to lock the syslog facility while logging
+
+[loggers.stackdriver]
+type = "StackDriver.StackdriverLogger"
+min_level = "Info"                      # default is Info
+project_name = "myapp"
+log_name = "myapp.log"
+key_file_path = "keyfile"
+access_token = "accesstoken"
+
+[loggers.file.testapp]
+filename = "/tmp/testapp.log"
+
+[loggers.syslog.testapp]
+identity = "testapp"
+
+[loggers.stackdriver.testapp]
+log_name = "testapp"
+
+[loggers.testapp]
+type = "LoggingExtras.TeeLogger"
+destinations = ["file.testapp", "syslog.testapp"]
+
+[loggers.testapptee]
+type = "LogRoller.RollingFileWriterTee"
+destination = "file.testapp"
+filename = "/tmp/testapptee.log"
+# sizelimit = 10240000
+# nfiles = 5
+# assumed_level = "Debug"                 # Debug, Info (default) or Error
+
+[loggers.plainfile]
+type = "LogRoller.RollingFileWriter"
+filename = "/tmp/testplain.log"
+# sizelimit = 10240000
+# nfiles = 5
+# assumed_level = "Debug"                 # Debug, Info (default) or Error

--- a/src/LogCompose.jl
+++ b/src/LogCompose.jl
@@ -2,8 +2,6 @@ module LogCompose
 
 using Pkg, Logging
 
-export logcompose
-
 include("compose.jl")
 include("connectors.jl")
 

--- a/src/compose.jl
+++ b/src/compose.jl
@@ -65,7 +65,6 @@ function logger(config::Dict{String,Any}, loggername::Vector)
     logcompose(loggertype, config, loggercfg)
 end
 
-logcompose(::Type{T}, config::Dict{String,Any}, logger_config::Dict{String,Any}) where {T} = @error("logcompose not implemented for type $T")
+logcompose(::Type{T}, config::Dict{String,Any}, logger_config::Dict{String,Any}) where {T} = error("logcompose not implemented for type $T")
 
 log_min_level(logger_config::Dict{String,Any}, default::String="Info") = getproperty(Logging, Symbol(get(logger_config, "min_level", default)))
-log_assumed_level(logger_config::Dict{String,Any}, default::String="Info") = getproperty(Logging, Symbol(get(logger_config, "assumed_level", default)))

--- a/src/compose.jl
+++ b/src/compose.jl
@@ -1,4 +1,4 @@
-using Logging, LogRoller, SyslogLogging, LoggingExtras
+using Logging
 
 name_parts(loggername) = split(loggername, '.')
 
@@ -42,12 +42,26 @@ function get_type(s::String, topmodule::Module=@__MODULE__)
     end
 end
 
+function get_type(s::String, modules::Vector{Module})
+    L = length(modules)
+    for idx in 1:L
+        try
+            return get_type(s, modules[idx])
+        catch ex
+            (idx == L) && rethrow(ex)
+        end
+    end
+end
+
 logger(configfile::String, loggername::String; section::String="") = logger(configuration(configfile; section=section), name_parts(loggername))
 logger(config::Dict{String,Any}, loggername::String) = logger(config, name_parts(loggername))
 function logger(config::Dict{String,Any}, loggername::Vector)
     loggercfg = flatten(config, loggername)
     loggertypestr = loggercfg["type"]
-    loggertype = get_type(loggertypestr)
+    loggertopmodule = Base.eval(Main, Symbol(get(loggercfg, "topmodule", "Main")))
+    modules = collect(Set([Main, loggertopmodule, @__MODULE__]))
+    loggertype = get_type(loggertypestr, modules)
+
     logcompose(loggertype, config, loggercfg)
 end
 

--- a/src/connectors.jl
+++ b/src/connectors.jl
@@ -2,7 +2,7 @@ module Connectors
 
 using Logging
 using ..LogCompose
-import ..LogCompose: logcompose, log_min_level, log_assumed_level
+import ..LogCompose: logcompose, log_min_level
 
 #--------------------------------------------------------------------
 # The connectors for individual logger implementations should ideally

--- a/src/connectors.jl
+++ b/src/connectors.jl
@@ -1,16 +1,18 @@
 module Connectors
 
+using Logging
 using ..LogCompose
 import ..LogCompose: logcompose, log_min_level, log_assumed_level
 
-using Logging, LogRoller, SyslogLogging, LoggingExtras, Sockets
-
 #--------------------------------------------------------------------
 # The connectors for individual logger implementations should ideally
-# be in their own packages.
+# be in their own packages. Here we implement connectors only for the
+# loggers in the stdlib Logging package.
 #--------------------------------------------------------------------
 
-function logcompose(::Type{Logging.SimpleLogger}, config::Dict{String,Any}, logger_config::Dict{String,Any})
+logcompose(::Type{Logging.NullLogger}, config::Dict{String,Any}, logger_config::Dict{String,Any}) = Logging.NullLogger()
+
+function logcompose(::Type{T}, config::Dict{String,Any}, logger_config::Dict{String,Any}) where {T <: Union{Logging.SimpleLogger, Logging.ConsoleLogger}}
     level = log_min_level(logger_config, "Info")
 
     streamname = strip(get(logger_config, "stream", "stdout"))
@@ -18,74 +20,9 @@ function logcompose(::Type{Logging.SimpleLogger}, config::Dict{String,Any}, logg
 
     stream = streamname == "stdout" ? stdout :
              streamname == "stderr" ? stderr :
-             open(streamname, "w+")
+             open(streamname, "a+")
 
-    Logging.SimpleLogger(stream, level)
-end
-
-const sysloglck = ReentrantLock()
-function logcompose(::Type{SyslogLogging.SyslogLogger}, config::Dict{String,Any}, logger_config::Dict{String,Any})
-    ident = logger_config["identity"]
-    level = log_min_level(logger_config, "Info")
-
-    kwargs = Dict{Symbol,Any}()
-
-    kwargs[:facility] = Symbol(get(logger_config, "facility", "user"))
-
-    if get(logger_config, "lock", false)
-        kwargs[:lck] = sysloglck
-    end
-
-    server_type = get(logger_config, "server_type", "local")
-    if (server_type == "tcp") || (server_type == "udp")
-        kwargs[:tcp] = (server_type == "tcp")
-        if haskey(logger_config, "server_host")
-            kwargs[:host] = logger_config["server_host"]
-        end
-        if haskey(logger_config, "server_port")
-            kwargs[:port] = logger_config["server_port"]
-        end
-    end
-    SyslogLogging.SyslogLogger(ident, level; kwargs...)
-end
-
-function logcompose(::Type{LogRoller.RollingLogger}, config::Dict{String,Any}, logger_config::Dict{String,Any})
-    filename = String(strip(logger_config["filename"]))
-    @assert !isempty(filename)
-
-    level = log_min_level(logger_config, "Info")
-    sizelimit = get(logger_config, "sizelimit", 10240000)
-    nfiles = get(logger_config, "nfiles", 5)
-    timestamp_identifier = Symbol(get(logger_config, "timestamp_identifier", "time"))
-
-    LogRoller.RollingLogger(filename, sizelimit, nfiles, level; timestamp_identifier=timestamp_identifier)
-end
-
-function logcompose(::typeof(LogRoller.RollingFileWriterTee), config::Dict{String,Any}, logger_config::Dict{String,Any})
-    filename = String(strip(logger_config["filename"]))
-    @assert !isempty(filename)
-
-    level = log_assumed_level(logger_config, "Info")
-    sizelimit = get(logger_config, "sizelimit", 10240000)
-    nfiles = get(logger_config, "nfiles", 5)
-    destination_name = logger_config["destination"]
-    destination = LogCompose.logger(config, destination_name)
-    LogRoller.RollingFileWriterTee(filename, sizelimit, nfiles, destination, level)
-end
-
-function logcompose(::typeof(LogRoller.RollingFileWriter), config::Dict{String,Any}, logger_config::Dict{String,Any})
-    filename = String(strip(logger_config["filename"]))
-    @assert !isempty(filename)
-
-    level = log_assumed_level(logger_config, "Info")
-    sizelimit = get(logger_config, "sizelimit", 10240000)
-    nfiles = get(logger_config, "nfiles", 5)
-    LogRoller.RollingFileWriter(filename, sizelimit, nfiles)
-end
-
-function logcompose(::Type{LoggingExtras.TeeLogger}, config::Dict{String,Any}, logger_config::Dict{String,Any})
-    destinations = [LogCompose.logger(config, dest) for dest in logger_config["destinations"]]
-    LoggingExtras.TeeLogger(destinations...)
+    T(stream, level)
 end
 
 end # module Connectors

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,14 @@ function test()
         end
     end
 
+    invalid_config = Dict{String,Any}(
+        "invalid" => Dict{String,Any}(
+            "type" => "UnknownModule.UnknownLogger"
+        )
+    )
+    @test_throws ErrorException LogCompose.logger(invalid_config, "invalid")
+    @test_throws ErrorException LogCompose.logcompose(String, invalid_config, invalid_config)
+
     try
         rm(simple_logfile; force=true)
     catch ex

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,7 +38,11 @@ function test()
         end
     end
 
-    rm(simple_logfile; force=true)
+    try
+        rm(simple_logfile; force=true)
+    catch ex
+        # ignore (occasionally fails with resource busy exception on Windows, because logger has not been gc'd yet)
+    end
 end
 
 test()

--- a/test/testapp.toml
+++ b/test/testapp.toml
@@ -1,56 +1,12 @@
-[loggers.default]
+[loggers.simple]
 type = "Logging.SimpleLogger"
 # min_level = "Debug"                   # Debug, Info (default) or Error
-stream = "/tmp/default.log"             # stdout (default), stderr or a filepath
+stream = "simple.log"                   # stdout (default), stderr or a filepath
 
-[loggers.file]
-type = "LogRoller.RollingLogger"
-# sizelimit = 10240000
-# nfiles = 5
+[loggers.console]
+type = "Logging.ConsoleLogger"
 # min_level = "Debug"                   # Debug, Info (default) or Error
-# timestamp_identifier = "time"
+stream = "stdout"                       # stdout (default), stderr or a filepath
 
-[loggers.syslog]
-type = "SyslogLogging.SyslogLogger"
-# min_level = "Info"                      # default is Info
-# facility = "user"                       # one of the facility types listed in Syslogs.jl (default is user)
-# server_type = "tcp"                     # tcp or udp or local (default)
-# server_host = 
-# server_port =
-# lock = false                            # whether to lock the syslog facility while logging
-
-# [loggers.stackdriver]
-# type = "StackDriver.StackdriverLogger"
-# min_level = "Info"                      # default is Info
-# project_name =
-# log_name =
-# key_file_path =
-# access_token =
-
-[loggers.file.testapp]
-filename = "/tmp/testapp.log"
-
-[loggers.syslog.testapp]
-identity = "testapp"
-
-[loggers.stackdriver.testapp]
-log_name = "testapp"
-
-[loggers.testapp]
-type = "LoggingExtras.TeeLogger"
-destinations = ["file.testapp", "syslog.testapp"]
-
-[loggers.testapptee]
-type = "LogRoller.RollingFileWriterTee"
-destination = "file.testapp"
-filename = "/tmp/testapptee.log"
-# sizelimit = 10240000
-# nfiles = 5
-# assumed_level = "Debug"                 # Debug, Info (default) or Error
-
-[loggers.plainfile]
-type = "LogRoller.RollingFileWriter"
-filename = "/tmp/testplain.log"
-# sizelimit = 10240000
-# nfiles = 5
-# assumed_level = "Debug"                 # Debug, Info (default) or Error
+[loggers.null]
+type = "Logging.NullLogger"


### PR DESCRIPTION
This is a refactor to separate out support for loggers other than the stdlib Logging package into their own packages.
It cleans up the dependencies of LogCompose. It now does not depend on anything other than stdlib.

Split out dependencies are:

- [LoggingExtrasCompose.jl](https://github.com/tanmaykm/LoggingExtrasCompose.jl)
- [LogRollerCompose.jl](https://github.com/tanmaykm/LogRollerCompose.jl)
- [SyslogLoggingCompose.jl](https://github.com/tanmaykm/SyslogLoggingCompose.jl)