### PR TITLE
More console logger support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["configure", "compose", "logging", "logger"]
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
 license = "MIT"
 desc = "Compose loggers and logger ensembles declaratively using configuration files"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/connectors.jl
+++ b/src/connectors.jl
@@ -12,7 +12,7 @@ import ..LogCompose: logcompose, log_min_level
 
 logcompose(::Type{Logging.NullLogger}, config::Dict{String,Any}, logger_config::Dict{String,Any}) = Logging.NullLogger()
 
-function logcompose(::Type{T}, config::Dict{String,Any}, logger_config::Dict{String,Any}) where {T <: Union{Logging.SimpleLogger, Logging.ConsoleLogger}}
+function logcompose(::Type{Logging.SimpleLogger}, config::Dict{String,Any}, logger_config::Dict{String,Any})
     level = log_min_level(logger_config, "Info")
 
     streamname = strip(get(logger_config, "stream", "stdout"))
@@ -22,7 +22,34 @@ function logcompose(::Type{T}, config::Dict{String,Any}, logger_config::Dict{Str
              streamname == "stderr" ? stderr :
              open(streamname, "a+")
 
-    T(stream, level)
+    Logging.SimpleLogger(stream, level)
+end
+
+function logcompose(::Type{Logging.ConsoleLogger}, config::Dict{String,Any}, logger_config::Dict{String,Any})
+    level = log_min_level(logger_config, "Info")
+
+    streamname = strip(get(logger_config, "stream", "stdout"))
+    @assert !isempty(streamname)
+
+    stream = streamname == "stdout" ? stdout :
+             streamname == "stderr" ? stderr :
+             open(streamname, "a+")
+
+    color = get(logger_config, "color", nothing)
+    color === nothing || (stream = IOContext(stream, :color=>color))
+
+    displaysize = get(logger_config, "displaysize", nothing)
+    if displaysize !== nothing
+        if !(displaysize isa AbstractVector{Int}) || length(displaysize) != 2
+            error("Expected [height,width] but got displaysize=$displaysize")
+        end
+        stream = IOContext(stream, :displaysize=>Tuple(displaysize))
+    end
+
+    show_limited = get(logger_config, "show_limited", true)
+    color isa Bool || error("Expected boolean but got show_limited=$show_limited")
+
+    Logging.ConsoleLogger(stream, level; show_limited=show_limited)
 end
 
 end # module Connectors

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,13 +22,19 @@ function test()
             let logger = LogCompose.logger(config, "console"; section="loggers")
                 with_logger(logger) do
                     @info("testconsole")
+                    @info("testconsole2", a=[111,222,333])
                 end
                 flush(logger.stream)
             end
         end
         close(writer)
-        log_file_contents = readlines(Base.pipe_reader(pipe))
-        @test findfirst("testconsole", log_file_contents[1]) !== nothing
+        log_file_contents = String(read(Base.pipe_reader(pipe)))
+        @test findfirst("testconsole", log_file_contents) !== nothing
+        @test findfirst("testconsole2", log_file_contents) !== nothing
+        # setting displaysize limits output
+        @test findfirst("111", log_file_contents) === nothing
+        # ANSI color codes were enabled
+        @test findfirst("\e", log_file_contents) !== nothing
         close(pipe)
     end
 

--- a/test/testapp.toml
+++ b/test/testapp.toml
@@ -7,6 +7,9 @@ stream = "simple.log"                   # stdout (default), stderr or a filepath
 type = "Logging.ConsoleLogger"
 # min_level = "Debug"                   # Debug, Info (default) or Error
 stream = "stdout"                       # stdout (default), stderr or a filepath
+color = true                            # force color output, even to non-tty
+# show_limited = false                  # disable limited output
+displaysize = [3, 50]                   # Set display size for formatting
 
 [loggers.null]
 type = "Logging.NullLogger"


### PR DESCRIPTION
Support additional fields known to ConsoleLogger
    
These are all useful for debugging, especially with ConsoleLogger inside a container:

* A way to force ANSI color codes
* A way to set the display size
* A way to disable output limiting
