### PR TITLE
fix(ConsoleLogger config): check show_limited is a bool instead of color

### DIFF
--- a/src/connectors.jl
+++ b/src/connectors.jl
@@ -47,7 +47,7 @@ function logcompose(::Type{Logging.ConsoleLogger}, config::Dict{String,Any}, log
     end
 
     show_limited = get(logger_config, "show_limited", true)
-    color isa Bool || error("Expected boolean but got show_limited=$show_limited")
+    show_limited isa Bool || error("Expected boolean but got show_limited=$show_limited")
 
     Logging.ConsoleLogger(stream, level; show_limited=show_limited)
 end


### PR DESCRIPTION
When configuring a ConsoleLogger with the minimal config of:

```
[loggers.console]
type = "Logging.ConsoleLogger"
# min_level = "Debug"             # Debug, Info (default) or Error
stream = "stdout"   
```

It would blow up with:
```
ERROR: LoadError: Expected boolean but got show_limited=true
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] logcompose(#unused#::Type{Logging.ConsoleLogger}, config::Dict{String, Any}, logger_config::Dict{String, Any})
   @ LogCompose.Connectors ~/depot/packages/LogCompose/QDbPx/src/connectors.jl:50
 [3] logger(config::Dict{String, Any}, loggername::Vector{SubString{String}})
   @ LogCompose ~/depot/packages/LogCompose/QDbPx/src/compose.jl:65
 [4] logger(config::Dict{String, Any}, loggername::String)
   @ LogCompose ~/depot/packages/LogCompose/QDbPx/src/compose.jl:57
....
```