### PR TITLE
Merge `LogComposeExtras` in as a package extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.9'
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - nightly
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -4,17 +4,24 @@ keywords = ["configure", "compose", "logging", "logger"]
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
 license = "MIT"
 desc = "Compose loggers and logger ensembles declaratively using configuration files"
-version = "0.2.1"
+version = "0.3"
+
+[weakdeps]
+LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
+
+[extensions]
+LoggingExtrasExt = "LoggingExtras"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [compat]
-julia = "1"
+julia = "1.9"
 
 [extras]
+LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "LoggingExtras"]

--- a/ext/LoggingExtrasExt.jl
+++ b/ext/LoggingExtrasExt.jl
@@ -1,0 +1,19 @@
+module LoggingExtrasExt
+
+using LoggingExtras, LogCompose
+import LogCompose: logcompose, log_min_level
+
+function logcompose(::Type{LoggingExtras.TeeLogger}, config::Dict{String,Any}, logger_config::Dict{String,Any})
+    destinations = [LogCompose.logger(config, dest) for dest in logger_config["destinations"]]
+    return LoggingExtras.TeeLogger(destinations...)
+end
+
+function logcompose(::Type{LoggingExtras.FileLogger}, config::Dict{String,Any}, logger_config::Dict{String,Any})
+    filename = logger_config["filename"]
+    append = get(logger_config, "append", false)
+    flush = get(logger_config, "flush", true)
+
+    return LoggingExtras.FileLogger(filename; append=append, always_flush=flush)
+end
+
+end # module

--- a/test/testapp.toml
+++ b/test/testapp.toml
@@ -13,3 +13,19 @@ displaysize = [3, 50]                   # Set display size for formatting
 
 [loggers.null]
 type = "Logging.NullLogger"
+
+[loggers.file1]
+type = "LoggingExtras.FileLogger"
+filename = "testapp1.log"
+append = true                   # file open mode (default: false)
+flush = true                    # flush after logging (default: true)
+
+[loggers.file2]
+type = "LoggingExtras.FileLogger"
+filename = "testapp2.log"
+append = true
+flush = true
+
+[loggers.tee]
+type = "LoggingExtras.TeeLogger"
+destinations = ["file1", "file2"]


### PR DESCRIPTION
This integrates the `LoggingExtrasCompose` package [0] as a package extension to `LogCompose`, to be loaded on-demand when `LoggingExtras` is also loaded.  This requires the Julia compat bounds to be bumped up to v1.9.

[0] https://github.com/tanmaykm/LoggingExtrasCompose.jl